### PR TITLE
Tellere opprettes under oppstart

### DIFF
--- a/src/main/kotlin/no/nav/eessi/pensjon/metrics/MetricsHelper.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/metrics/MetricsHelper.kt
@@ -5,9 +5,29 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import javax.annotation.PostConstruct
 
 @Component
 class MetricsHelper(val registry: MeterRegistry, @Autowired(required = false) val configuration: Configuration = Configuration()) {
+
+    @PostConstruct
+    fun initCounters() {
+        listOf("consumeOutgoingSed",
+                "hentperson",
+                "hentSed",
+                "settSensitiv",
+                "disoverSTS",
+                "getSystemOidcToken",
+                "hentSeds").forEach {counterName ->
+            Counter.builder(counterName)
+                    .tag(configuration.typeTag, configuration.successTypeTagValue)
+                    .register(registry)
+
+            Counter.builder(counterName)
+                    .tag(configuration.typeTag, configuration.failureTypeTagValue)
+                    .register(registry)
+        }
+    }
 
     fun <R> measure(
             method: String,
@@ -15,33 +35,24 @@ class MetricsHelper(val registry: MeterRegistry, @Autowired(required = false) va
             success: String = configuration.successTypeTagValue,
             meterName: String = configuration.measureMeterName,
             eventType: String = configuration.callEventTypeTagValue,
-            extraTags: Array<String> = arrayOf(),
-            description: String = "",
             block: () -> R): R {
 
-        var throwableClass = configuration.noExceptionTypeTagValue
         var typeTag = success
 
         try {
             return Timer.builder("$meterName.${configuration.measureTimerSuffix}")
-                    .description(if (description.isEmpty()) null else description)
                     .tag(configuration.methodTag, method)
-                    .tags(*extraTags)
                     .register(registry)
                     .recordCallable {
                         block.invoke()
                     }
         } catch (throwable: Throwable) {
-            throwableClass = throwable.javaClass.simpleName
             typeTag = failure
             throw throwable
         } finally {
             try {
                 Counter.builder(meterName)
-                        .description(if (description.isEmpty()) null else description)
-                        .tags(*extraTags)
                         .tag(configuration.methodTag, method)
-                        .tag(configuration.exceptionTag, throwableClass)
                         .tag(configuration.typeTag, typeTag)
                         .register(registry)
                         .increment()
@@ -51,28 +62,7 @@ class MetricsHelper(val registry: MeterRegistry, @Autowired(required = false) va
         }
     }
 
-    fun increment(
-            event: String,
-            eventType: String = configuration.eventTypeTagValue,
-            extraTags: Array<String> = arrayOf(),
-            throwable: Throwable? = null,
-            meterName: String = configuration.incrementMeterName,
-            description: String = "") {
-        try {
-            Counter.builder(meterName)
-                    .description(if (description.isEmpty()) null else description)
-                    .tag(configuration.eventTag, event)
-                    .tags(*extraTags)
-                    .tag(configuration.typeTag, eventType)
-                    .tag(configuration.exceptionTag, if (throwable == null) configuration.noExceptionTypeTagValue else throwable.javaClass.simpleName)
-                    .register(registry)
-                    .increment()
-        } catch (t: Throwable) {
-            // ignoring on purpose
-        }
-    }
-
-    data class Configuration(
+    class Configuration(
             val incrementMeterName: String = "event",
             val measureMeterName: String = "method",
             val measureTimerSuffix: String = "timer",
@@ -80,14 +70,10 @@ class MetricsHelper(val registry: MeterRegistry, @Autowired(required = false) va
             val eventTag: String = "event",
             val methodTag: String = "method",
             val typeTag: String = "type",
-            val exceptionTag: String = "exception",
 
             val successTypeTagValue: String = "successful",
             val failureTypeTagValue: String = "failed",
 
-            val eventTypeTagValue: String = "occurred",
-
-            val callEventTypeTagValue: String = "called",
-            val noExceptionTypeTagValue: String = "none"
+            val callEventTypeTagValue: String = "called"
     )
 }

--- a/src/test/kotlin/no/nav/eessi/pensjon/metrics/MetricsHelperTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/metrics/MetricsHelperTest.kt
@@ -34,8 +34,7 @@ internal class MetricsHelperTest {
             registry.counter(
                     config.measureMeterName,
                     config.methodTag, "dummy",
-                    config.typeTag, config.successTypeTagValue,
-                    config.exceptionTag, config.noExceptionTypeTagValue)
+                    config.typeTag, config.successTypeTagValue)
                 .count(),
             0.0001)
     }
@@ -55,8 +54,7 @@ internal class MetricsHelperTest {
             registry.counter(
                     config.measureMeterName,
                     config.methodTag, "dummy",
-                    config.typeTag, config.failureTypeTagValue,
-                    config.exceptionTag, "RuntimeException")
+                    config.typeTag, config.failureTypeTagValue)
                 .count(),
             0.0001)
     }
@@ -76,64 +74,10 @@ internal class MetricsHelperTest {
             registry.counter(
                     config.measureMeterName,
                     config.methodTag, "dummy",
-                    config.typeTag, config.failureTypeTagValue,
-                    config.exceptionTag, "IOError")
+                    config.typeTag, config.failureTypeTagValue)
                 .count(),
             0.0001)
     }
-
-    @Test
-    fun measure_supports_overriding_in_call() {
-        metricsHelper.measure(
-            method = "mymethod",
-            failure = "feilede",
-            success = "vellykkede",
-            extraTags = arrayOf("my_tag", "my_value"),
-            description = "My metric is the best"
-        ) {
-            // no exception here
-        }
-
-        assertEquals(
-            1.0,
-            registry.counter(
-                    config.measureMeterName,
-                    config.methodTag, "mymethod",
-                    config.typeTag, "vellykkede",
-                    config.exceptionTag, config.noExceptionTypeTagValue,
-                    "my_tag", "my_value")
-                    .count(),
-                0.0001)
-    }
-
-    @Test
-    fun measure_supports_customization() {
-        val myCustomSuccessTypeTagValue = "vellykkede"
-        val customizedMetricsHelper =
-                MetricsHelper(
-                        registry,
-                        MetricsHelper.Configuration(successTypeTagValue = myCustomSuccessTypeTagValue))
-
-        customizedMetricsHelper.measure(
-            method = "mymethod",
-            extraTags = arrayOf("my_tag", "my_value"),
-            description = "My metric is the best"
-        ) {
-            // no exception here
-        }
-
-        assertEquals(
-            1.0,
-            registry.counter(
-                    config.measureMeterName,
-                    config.methodTag, "mymethod",
-                    config.typeTag, myCustomSuccessTypeTagValue,
-                    config.exceptionTag, config.noExceptionTypeTagValue,
-                    "my_tag", "my_value")
-                    .count(),
-                0.0001)
-    }
-
 
     @Test
     fun measure_registers_a_timer_too() {
@@ -154,44 +98,5 @@ internal class MetricsHelperTest {
                 100.0,
                 timer.totalTime(TimeUnit.MILLISECONDS),
                 10.0)
-    }
-
-    @Test
-    fun increment_increments_a_counter() {
-        metricsHelper.increment(
-                event = "myevent",
-                eventType = "mottatt",
-                extraTags = arrayOf("my_tag", "my_value")
-        )
-
-        assertEquals(1.0,
-                registry.counter(
-                        config.incrementMeterName,
-                        config.eventTag, "myevent",
-                        config.typeTag, "mottatt",
-                        config.exceptionTag, config.noExceptionTypeTagValue,
-                        "my_tag", "my_value"
-                ).count(),
-                0.0001)
-
-    }
-
-    @Test
-    fun increment_can_take_a_throwable() {
-        metricsHelper.increment(
-                event = "myevent",
-                eventType = "failed",
-                throwable = RuntimeException("BOOM!")
-        )
-
-        assertEquals(1.0,
-                registry.counter(
-                        config.incrementMeterName,
-                        config.eventTag, "myevent",
-                        config.typeTag, "failed",
-                        config.exceptionTag, "RuntimeException"
-                ).count(),
-                0.0001)
-
     }
 }


### PR DESCRIPTION
method Counters opprettes ved oppstart, man må desverre huske å legge de inn i denne configen når man legger til en ny.

Fjernet increment, fordi vi bruker den ikke til noe og denne microservicen har antageligvis blitt så stor som den kommer noen gang til å bli så vi får antageligvis aldri bruk for increment.

Fjernet exception tagger fordi vi ikke har de under opprettelse første gang og vi trenger de strengt talt ikke så detaljert for den eneste hensikten å lage alarmer ved feil. Detaljert info kan sjekkes i loggen istedet