### PR TITLE
Upgrade Spring Boot from 2.1.6 -> 2.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
 
 	ext {
 		kotlinVersion = '1.3.41'
-		springBootVersion = '2.1.6.RELEASE'
+		springBootVersion = '2.2.2.RELEASE'
 		cxfVersion = '3.3.2'
 		oidcTokenSupportVersion = '0.2.9'
 		logstashLogbackVersion = '6.1'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
   kafka:
     listener:
       ack-mode: manual
+      missingTopicsFatal: true  # app will not start if topics don't exist
     consumer:
       enable-auto-commit: false
       max-poll-records: 1

--- a/src/test/kotlin/no/nav/eessi/pensjon/BegrensInnsynIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/BegrensInnsynIntegrationTest.kt
@@ -39,13 +39,14 @@ import java.util.concurrent.TimeUnit
 import javax.ws.rs.HttpMethod
 
 private const val SED_SENDT_TOPIC = "eessi-basis-sedSendt-v1"
+private const val SED_MOTTATT_TOPIC = "eessi-basis-sedMottatt-v1"
 
 private lateinit var mockServer : ClientAndServer
 
 @SpringBootTest(classes = [ BegrensInnsynIntegrationTest.TestConfig::class])
 @ActiveProfiles("integrationtest")
 @DirtiesContext
-@EmbeddedKafka(count = 1, controlledShutdown = true, topics = [SED_SENDT_TOPIC])
+@EmbeddedKafka(count = 1, controlledShutdown = true, topics = [SED_SENDT_TOPIC, SED_MOTTATT_TOPIC])
 class BegrensInnsynIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
This also upgrades Spring Kafa from 2.2 to 2.34 - which seems
to affect missingTopicsFatal-behaviour. The app now seems to fail
if the topics needed don't exist.

https://docs.spring.io/spring-kafka/docs/2.3.4.RELEASE/reference/html/#whats-new-part