### PR TITLE
Introduce Spring Retry on getSed-calls to EUX

### DIFF
--- a/src/main/kotlin/no/nav/eessi/pensjon/EessiPensjonBegrensInnsynApplication.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/EessiPensjonBegrensInnsynApplication.kt
@@ -2,8 +2,10 @@ package no.nav.eessi.pensjon
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.retry.annotation.EnableRetry
 
 @SpringBootApplication
+@EnableRetry
 class EessiPensjonBegrensInnsynApplication
 
 fun main(args: Array<String>) {

--- a/src/test/kotlin/no/nav/eessi/pensjon/BegrensInnsynIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/BegrensInnsynIntegrationTest.kt
@@ -30,6 +30,7 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker
 import org.springframework.kafka.test.context.EmbeddedKafka
 import org.springframework.kafka.test.utils.ContainerTestUtils
 import org.springframework.kafka.test.utils.KafkaTestUtils
+import org.springframework.retry.annotation.EnableRetry
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import java.nio.file.Files
@@ -46,6 +47,7 @@ private lateinit var mockServer : ClientAndServer
 @SpringBootTest(classes = [ BegrensInnsynIntegrationTest.TestConfig::class])
 @ActiveProfiles("integrationtest")
 @DirtiesContext
+@EnableRetry
 @EmbeddedKafka(count = 1, controlledShutdown = true, topics = [SED_SENDT_TOPIC, SED_MOTTATT_TOPIC])
 class BegrensInnsynIntegrationTest {
 

--- a/src/test/kotlin/no/nav/eessi/pensjon/services/eux/EuxServiceTest.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/services/eux/EuxServiceTest.kt
@@ -1,0 +1,107 @@
+package no.nav.eessi.pensjon.services.eux
+
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.retry.annotation.EnableRetry
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.HttpServerErrorException
+import org.springframework.web.client.RestTemplate
+
+
+@ExtendWith(MockKExtension::class, SpringExtension::class)
+@ContextConfiguration
+internal class EuxServiceTest {
+
+    @Configuration
+    @EnableRetry // To make @Retryable work
+    @ComponentScan("no.nav.eessi.pensjon.services.eux")
+    class Config {
+        @Bean fun restTemplate() = mockk<RestTemplate>()
+    }
+
+    @Autowired
+    lateinit var euxService: EuxService
+
+    @Autowired
+    lateinit var restTemplate: RestTemplate
+
+    private val rinaSakId = "42"
+    private val rinaDokumentId = "666"
+    private val sedAsJsonString = "SED as a JSON-string"
+
+    @Test
+    fun `getSed lykkes - returnerer verdi`() {
+        every {
+            restTemplate.exchange("/buc/$rinaSakId/sed/$rinaDokumentId", HttpMethod.GET,null, String::class.java)
+        } returns ResponseEntity(sedAsJsonString, HttpStatus.OK)
+
+        assertEquals(sedAsJsonString, euxService.getSed(rinaSakId = rinaSakId, rinaDokumentId = rinaDokumentId))
+    }
+
+    @Test
+    fun `getSed feiler første gang med HttpServerError, men lykkes andre gang - returnerer verdi`() {
+        every {
+            restTemplate.exchange("/buc/$rinaSakId/sed/$rinaDokumentId", HttpMethod.GET,null, String::class.java)
+        }.throws(HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR))
+                .andThen(ResponseEntity(sedAsJsonString, HttpStatus.OK))
+
+        assertEquals(sedAsJsonString, euxService.getSed(rinaSakId = rinaSakId, rinaDokumentId = rinaDokumentId))
+    }
+
+    @Test
+    fun `getSed feiler med Unautorized første gang, men lykkes andre gang - returnerer verdi`() {
+        every {
+            restTemplate.exchange("/buc/$rinaSakId/sed/$rinaDokumentId", HttpMethod.GET,null, String::class.java)
+        }.throws(UnauthorizedException())
+                .andThen(ResponseEntity(sedAsJsonString, HttpStatus.OK))
+
+        assertEquals(sedAsJsonString, euxService.getSed(rinaSakId = rinaSakId, rinaDokumentId = rinaDokumentId))
+    }
+
+    @Test
+    fun `getSed feiler hver gang med Unauthorized - det kastes til slutt exception`() {
+        every {
+            restTemplate.exchange("/buc/$rinaSakId/sed/$rinaDokumentId", HttpMethod.GET, null, String::class.java)
+        }.throws(UnauthorizedException())
+
+        assertThrows<HttpClientErrorException.Unauthorized> {
+            euxService.getSed(rinaSakId = rinaSakId, rinaDokumentId = rinaDokumentId)
+        }
+    }
+
+    @Test
+    fun `getSed feiler med en annen HttpClientError - det kastes exception med en gang`() {
+
+        every {
+            restTemplate.exchange("/buc/$rinaSakId/sed/$rinaDokumentId", HttpMethod.GET, null, String::class.java)
+        }.throws(BadRequestException())
+                .andThen(ResponseEntity(sedAsJsonString, HttpStatus.OK))
+
+        assertThrows<HttpClientErrorException.BadRequest> {
+            euxService.getSed(rinaSakId = rinaSakId, rinaDokumentId = rinaDokumentId)
+        }
+    }
+
+    private fun UnauthorizedException() =
+            HttpClientErrorException.create(HttpStatus.UNAUTHORIZED, HttpStatus.UNAUTHORIZED.name, HttpHeaders.EMPTY, "{}".toByteArray(), null)
+
+    private fun BadRequestException() =
+            HttpClientErrorException.create(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.name, HttpHeaders.EMPTY, "{}".toByteArray(), null)
+
+}
+


### PR DESCRIPTION
This is an effort to mitigate EUX-1947.
Note that the @Retryable-annotation only works on calls between classes
See: https://github.com/spring-projects/spring-retry/issues/180