### PR TITLE
Switch from Java 8 to Java 11

### DIFF
--- a/.github/workflows/bygg_alle_brancher.yml
+++ b/.github/workflows/bygg_alle_brancher.yml
@@ -16,6 +16,12 @@ jobs:
       - name: 'Pull repo'
         uses: actions/checkout@v1
 
+      # JAVA 11
+      - name: 'Java 11'
+        uses: actions/setup-java@v1.3.0
+        with:
+          java-version: 11
+
       # BYGGER DOCKER CONTAINER
       - name: 'Bygg'
         run: |

--- a/.github/workflows/bygg_og_deploy_test.yml
+++ b/.github/workflows/bygg_og_deploy_test.yml
@@ -24,6 +24,12 @@ jobs:
       - name: 'Setter Image'
         run: echo "::set-env name=IMAGE::docker.pkg.github.com/${{ github.repository }}/eessi-pensjon-begrens-innsyn:${{ env.DATE }}---${{ env.COMMIT_HASH }}"
 
+      # JAVA 11
+      - name: 'Java 11'
+        uses: actions/setup-java@v1.3.0
+        with:
+          java-version: 11
+
       # BYGGER DOCKER CONTAINER
       - name: 'Bygg og publiser docker image'
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM navikt/java:8-appdynamics
+FROM navikt/java:11-appdynamics
 
 COPY build/libs/eessi-pensjon-begrens-innsyn-*.jar /app/app.jar
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ plugins {
 	id 'com.cosminpolifronie.gradle.plantuml' version '1.6.0'
 }
 
+assert JavaVersion.current().isJava11Compatible(): "Java 11 or newer is required"
+
 apply plugin: 'kotlin'
 apply plugin: 'kotlin-spring'
 apply plugin: 'org.springframework.boot'
@@ -71,6 +73,8 @@ dependencies {
 	// Apache CXF
 	implementation("org.apache.cxf:cxf-spring-boot-starter-jaxws:${cxfVersion}")
 	implementation("org.apache.cxf:cxf-rt-ws-security:${cxfVersion}")
+	implementation("com.sun.xml.ws:jaxws-ri:2.3.2")
+
 	implementation("commons-io:commons-io:2.6")
 
 	// Allows for variable expiration-date of each cache-entry
@@ -111,17 +115,21 @@ test {
 	useJUnitPlatform()
 }
 
+java {
+	sourceCompatibility = JavaVersion.VERSION_11
+	targetCompatibility = JavaVersion.VERSION_11
+}
 compileKotlin {
 	kotlinOptions {
 		freeCompilerArgs = ["-Xjsr305=strict"]
-		jvmTarget = "1.8"
+		jvmTarget = "11"
 	}
 }
 
 compileTestKotlin {
 	kotlinOptions {
 		freeCompilerArgs = ['-Xjsr305=strict']
-		jvmTarget = '1.8'
+		jvmTarget = '11'
 	}
 }
 


### PR DESCRIPTION
When this is applied you need to change the JDK you use for development
from Java 8 to at least Java 11.

See: https://confluence.adeo.no/x/MlrfFQ